### PR TITLE
Search by type feature+

### DIFF
--- a/src/analysis/polarity_search.ml
+++ b/src/analysis/polarity_search.ml
@@ -145,40 +145,17 @@ let execute_query query env dirs =
   in
   List.fold_left dirs ~init:(direct None []) ~f:recurse
 
-let execute_query_as_type_search ?(limit = 100) ~env ~query ~modules doc_ctx =
-  let direct dir acc =
-    Env.fold_values
-      (fun _ path desc acc ->
-        let d = desc.Types.val_type in
-        match match_query env query d with
-        | Some cost ->
-          let path = Printtyp.rewrite_double_underscore_paths env path in
-          let name = Format.asprintf "%a" Printtyp.path path in
-          let doc = Type_search.get_doc doc_ctx env name in
-          let loc = desc.Types.val_loc in
-          let typ =
-            Format.asprintf "%a"
-              (Type_utils.Printtyp.type_scheme env)
-              desc.Types.val_type
-          in
-          let constructible = Type_search.make_constructible name d in
-          Query_protocol.{ cost; name; typ; loc; doc; constructible } :: acc
-        | None -> acc)
-      dir env acc
-  in
-  let rec recurse acc (Trie (_, dir, children)) =
-    match
-      ignore (Env.find_module_by_name dir env);
-      Lazy.force children
-    with
-    | children ->
-      List.fold_left ~f:recurse ~init:(direct (Some dir) acc) children
-    | exception Not_found ->
-      Logger.notify ~section:"polarity-search" "%S not found"
-        (String.concat ~sep:"." (Longident.flatten dir));
-      acc
-  in
-  modules
-  |> List.fold_left ~init:(direct None []) ~f:recurse
+(* [execute_query_as_type_search] runs a standard polarity_search query and map
+   the result for compatibility with the type-search interface. *)
+let execute_query_as_type_search ?(limit = 100) ~env ~query ~modules () =
+  execute_query query env modules
+  |> List.map ~f:(fun (cost, path, desc) ->
+         let path = Printtyp.rewrite_double_underscore_paths env path in
+         let name = Format.asprintf "%a" Printtyp.path path in
+         let doc = None in
+         let loc = desc.Types.val_loc in
+         let typ = desc.Types.val_type in
+         let constructible = Type_search.make_constructible name typ in
+         Query_protocol.{ cost; name; typ; loc; doc; constructible })
   |> List.sort ~cmp:Type_search.compare_result
   |> List.take_n limit

--- a/src/analysis/polarity_search.ml
+++ b/src/analysis/polarity_search.ml
@@ -150,8 +150,11 @@ let execute_query query env dirs =
 let execute_query_as_type_search ?(limit = 100) ~env ~query ~modules () =
   execute_query query env modules
   |> List.map ~f:(fun (cost, path, desc) ->
-         let path = Printtyp.rewrite_double_underscore_paths env path in
-         let name = Format.asprintf "%a" Printtyp.path path in
+         let name =
+           Printtyp.wrap_printing_env env @@ fun () ->
+           let path = Printtyp.rewrite_double_underscore_paths env path in
+           Format.asprintf "%a" Printtyp.path path
+         in
          let doc = None in
          let loc = desc.Types.val_loc in
          let typ = desc.Types.val_type in

--- a/src/analysis/type_search.ml
+++ b/src/analysis/type_search.ml
@@ -93,20 +93,16 @@ let compute_value query env _ path desc acc =
   let open Merlin_sherlodoc in
   let d = desc.Types.val_type in
   let typ = sherlodoc_type_of env d in
-  let path = Printtyp.rewrite_double_underscore_paths env path in
-  let name = Format.asprintf "%a" Printtyp.path path in
+  let name =
+    Printtyp.wrap_printing_env env @@ fun () ->
+    let path = Printtyp.rewrite_double_underscore_paths env path in
+    Format.asprintf "%a" Printtyp.path path
+  in
   let cost = Query.distance_for query ~path:name typ in
   if cost >= 1000 then acc
   else
-    (* let doc = get_doc doc_ctx env name in *)
     let doc = None in
     let loc = desc.Types.val_loc in
-    (* let typ =
-         Printtyp.wrap_printing_env env @@ fun () ->
-           Format.asprintf "%a"
-             (Type_utils.Printtyp.type_scheme env)
-             desc.Types.val_type
-       in *)
     let typ = desc.Types.val_type in
     let constructible = make_constructible name d in
     Query_protocol.{ cost; name; typ; loc; doc; constructible } :: acc

--- a/src/analysis/type_search.ml
+++ b/src/analysis/type_search.ml
@@ -69,12 +69,9 @@ let doc_to_option = function
   | `Builtin doc | `Found doc -> Some doc
   | _ -> None
 
-let get_doc doc_ctx env name =
-  match doc_ctx with
-  | None -> None
-  | Some (config, local_defs, comments, pos) ->
-    Locate.get_doc ~config ~env ~local_defs ~comments ~pos (`User_input name)
-    |> doc_to_option
+let get_doc ~config ~env ~local_defs ~comments ~pos name =
+  Locate.get_doc ~config ~env ~local_defs ~comments ~pos (`User_input name)
+  |> doc_to_option
 
 let compare_result Query_protocol.{ cost = cost_a; name = a; doc = doc_a; _ }
     Query_protocol.{ cost = cost_b; name = b; doc = doc_b; _ } =
@@ -92,7 +89,7 @@ let compare_result Query_protocol.{ cost = cost_a; name = a; doc = doc_a; _ }
     | _ -> c
   else c
 
-let compute_value doc_ctx query env _ path desc acc =
+let compute_value query env _ path desc acc =
   let open Merlin_sherlodoc in
   let d = desc.Types.val_type in
   let typ = sherlodoc_type_of env d in
@@ -101,25 +98,28 @@ let compute_value doc_ctx query env _ path desc acc =
   let cost = Query.distance_for query ~path:name typ in
   if cost >= 1000 then acc
   else
-    let doc = get_doc doc_ctx env name in
+    (* let doc = get_doc doc_ctx env name in *)
+    let doc = None in
     let loc = desc.Types.val_loc in
-    let typ =
-      Format.asprintf "%a"
-        (Type_utils.Printtyp.type_scheme env)
-        desc.Types.val_type
-    in
+    (* let typ =
+         Printtyp.wrap_printing_env env @@ fun () ->
+           Format.asprintf "%a"
+             (Type_utils.Printtyp.type_scheme env)
+             desc.Types.val_type
+       in *)
+    let typ = desc.Types.val_type in
     let constructible = make_constructible name d in
     Query_protocol.{ cost; name; typ; loc; doc; constructible } :: acc
 
-let compute_values doc_ctx query env lident acc =
-  Env.fold_values (compute_value doc_ctx query env) lident env acc
+let compute_values query env lident acc =
+  Env.fold_values (compute_value query env) lident env acc
 
-let values_from_module doc_ctx query env lident acc =
+let values_from_module query env lident acc =
   let rec aux acc lident =
     match Env.find_module_by_name lident env with
     | exception _ -> acc
     | _ ->
-      let acc = compute_values doc_ctx query env (Some lident) acc in
+      let acc = compute_values query env (Some lident) acc in
       Env.fold_modules
         (fun name _ mdl acc ->
           match mdl.Types.md_type with
@@ -131,12 +131,12 @@ let values_from_module doc_ctx query env lident acc =
   in
   aux acc lident
 
-let run ?(limit = 100) ~env ~query ~modules doc_ctx =
-  let init = compute_values doc_ctx query env None [] in
+let run ?(limit = 100) ~env ~query ~modules () =
+  let init = compute_values query env None [] in
   modules
   |> List.fold_left ~init ~f:(fun acc name ->
          let lident = Longident.Lident name in
-         values_from_module doc_ctx query env lident acc)
+         values_from_module query env lident acc)
   |> List.sort ~cmp:compare_result
   |> List.take_n limit
 

--- a/src/analysis/type_search.mli
+++ b/src/analysis/type_search.mli
@@ -36,22 +36,22 @@ val run :
   env:Env.t ->
   query:Merlin_sherlodoc.Query.t ->
   modules:string list ->
-  (Mconfig.t * Mtyper.typedtree * (string * Location.t) list * Lexing.position)
-  option ->
-  Query_protocol.type_search_result list
+  unit ->
+  Types.type_expr Query_protocol.type_search_result list
 
 val get_doc :
-  (Mconfig.t
-  * Mtyper.typedtree
-  * (string * Warnings.loc) list
-  * Lexing.position)
-  option ->
-  Env.t ->
+  config:Mconfig.t ->
+  env:Env.t ->
+  local_defs:Mtyper.typedtree ->
+  comments:(string * Location.t) list ->
+  pos:Lexing.position ->
   string ->
   string option
 
 val make_constructible : string -> Types.type_expr -> string
 val compare_result :
-  Query_protocol.type_search_result -> Query_protocol.type_search_result -> int
+  _ Query_protocol.type_search_result ->
+  _ Query_protocol.type_search_result ->
+  int
 
 val classify_query : string -> [ `By_type of string | `Polarity of string ]

--- a/src/frontend/query_protocol.ml
+++ b/src/frontend/query_protocol.ml
@@ -67,9 +67,9 @@ end
 
 type completions = Compl.t
 
-type type_search_result =
+type 'a type_search_result =
   { name : string;
-    typ : string;
+    typ : 'a;
     loc : Location_aux.t;
     doc : string option;
     cost : int;
@@ -150,7 +150,7 @@ type _ t =
   | Polarity_search : string * Msource.position -> completions t
   | Type_search :
       string * Msource.position * int * bool
-      -> type_search_result list t
+      -> string type_search_result list t
   | Refactor_open :
       [ `Qualify | `Unqualify ] * Msource.position
       -> (string * Location.t) list t


### PR DESCRIPTION
Fetching the doc and printing type can be expensive, I moved it to a separate pass so that we don't do it for values that would be discarded after.

I also added back the printing environment setters that play a role in the correct functioning of the short-paths feature.

WDYT ?